### PR TITLE
Reserve deployment steps for master branch commits only

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -3,10 +3,13 @@
 - service: github-api
   command: npm run production-test
 - service: github-api
+  tag: "master"
   type: push
   image_name: databraiddb/github-api
   encrypted_dockercfg_path: dockercfg.encrypted
 - service: awsdeployment
+  tag: "master"
   command: aws ecs register-task-definition --cli-input-json file:///deploy/tasks/github-api.json
 - service: awsdeployment
+  tag: "master"
   command: aws ecs update-service --cluster databraid-cluster --service github-api-service --task-definition github-api


### PR DESCRIPTION
See [these Codeship docs](https://documentation.codeship.com/pro/builds-and-configuration/steps/#limiting-steps-to-specific-branches-or-tags) for details.